### PR TITLE
Refactored /repos to /projects

### DIFF
--- a/franklin/builder/serializers.py
+++ b/franklin/builder/serializers.py
@@ -139,9 +139,12 @@ class SiteOnlySerializer(serializers.ModelSerializer):
 
 class FlatSiteSerializer(serializers.ModelSerializer):
     def to_representation(self, data):
-        env = data.get_default_environment()
+        build = BranchBuild.objects.filter(site=data)\
+                                   .order_by('-created').first()
         site_serializer = SiteOnlySerializer(data)
-        default_env_serializer = EnvironmentStatusSerializer(env)
         result = site_serializer.data
-        result['default_environment'] = default_env_serializer.data
+        result['build'] = {}
+        if build:
+            latest_build_serializer = BranchBuildSerializer(build)
+            result['build'] = latest_build_serializer.data
         return result

--- a/franklin/core/urls.py
+++ b/franklin/core/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
     url(r'^webhook/$', github_webhook, name='webhook'),
 
     # Registered Repo Operations
-    url(r'^repos/$', repository_list, name='repo_list'),
+    url(r'^projects/$', repository_list, name='repo_list'),
     url(r'^repos/(?P<pk>[0-9]+)$', repository_detail, name='repo_details'),
     url(r'^repos/(?P<pk>[0-9]+)/deploy$', deploy, name='repo_deploy'),
 

--- a/franklin/github/serializers.py
+++ b/franklin/github/serializers.py
@@ -10,7 +10,7 @@ class HeadCommitSerializer(serializers.Serializer):
     id = serializers.CharField(min_length=40, max_length=40)
     # Also available
     # message, timestamp, url, author{}, committer{}, ...
-    
+
 
 class RepositorySerializer(serializers.Serializer):
     full_name = serializers.CharField(max_length=100)

--- a/franklin/github/views.py
+++ b/franklin/github/views.py
@@ -33,11 +33,7 @@ def repository_list(request):
             request.user.details.update_repos_for_user(github_repos)
         sites = request.user.details.sites.filter(is_active=True).all()
         site_serializer = FlatSiteSerializer(sites, many=True)
-        user_serializer = UserSerializer(request.user)
-        return Response({
-            'repos': site_serializer.data,
-            'user': user_serializer.data
-        }, status=status.HTTP_200_OK)
+        return Response(site_serializer.data, status=status.HTTP_200_OK)
     elif request.method == 'POST':
         # TODO - #53 will have us refactoring all errors returned from our
         # external dependencies. It will need to handle cases like this where


### PR DESCRIPTION
Connected to #106

GET `/repos` is now located at `/projects` and returns a payload that has everything we discussed (see below image). Only thing missing is the build status in the build object.

POST `/repos` is now located at `/projects`  Nothing else has changed for that endpoint.