### PR TITLE
Refactoring permissions and project registration

### DIFF
--- a/franklin/builder/migrations/0018_auto_20160316_1844.py
+++ b/franklin/builder/migrations/0018_auto_20160316_1844.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('builder', '0017_auto_20160216_1953'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='environment',
+            name='deploy_type',
+            field=models.CharField(choices=[('BCH', 'branch'), ('TAG', 'tag'), ('PRO', 'promote')], default='BCH', max_length=3),
+        ),
+        migrations.AlterField(
+            model_name='environment',
+            name='status',
+            field=models.CharField(choices=[('REG', 'registered'), ('BLD', 'building'), ('SUC', 'success'), ('FAL', 'failed')], default='REG', max_length=3),
+        ),
+    ]

--- a/franklin/builder/models.py
+++ b/franklin/builder/models.py
@@ -85,9 +85,14 @@ class Site(models.Model):
         return self.environments.filter(~Q(deploy_type=Environment.PROMOTE))\
                                 .first()
 
-    def save(self, *args, **kwargs):
+    def save(self, user=None, *args, **kwargs):
         if not self.deploy_key:
             self.deploy_key, self.deploy_key_secret = generate_ssh_keys()
+        if not self.environments.exists() and user:
+            branch = get_default_branch(self, user)
+            self.environments.create(
+                    name=self.DEFAULT_ENV, deploy_type=Environment.PROMOTE)
+            self.environments.create(name='Staging', branch=branch)
         super(Site, self).save(*args, **kwargs)
 
     def __str__(self):

--- a/franklin/core/helpers.py
+++ b/franklin/core/helpers.py
@@ -1,8 +1,5 @@
-import hmac
-import hashlib
 import json
 import logging
-import os
 import requests
 import sys
 
@@ -11,7 +8,7 @@ from django.core.urlresolvers import reverse
 from Crypto.PublicKey import RSA
 from requests.exceptions import ConnectionError, HTTPError, Timeout
 from rest_framework import exceptions, HTTP_HEADER_ENCODING
-from rest_framework import status, permissions
+from rest_framework import status
 from rest_framework.authentication import BaseAuthentication,\
                                           get_authorization_header
 from social.apps.django_app.default.models import UserSocialAuth
@@ -62,21 +59,6 @@ def generate_ssh_keys():
     key = RSA.generate(2048)
     pubkey = key.publickey().exportKey('OpenSSH')
     return (pubkey.decode('UTF8'), key.exportKey('PEM').decode('UTF8'))
-
-
-class GithubOnly(permissions.BasePermission):
-    """ Security Check for certain API endpoints only called by Github."""
-
-    def has_permission(self, request, view):
-        secret = request.META.get("HTTP_X_HUB_SIGNATURE")
-        if secret:
-            # must convert to bytes for python 3.5 bug in hmac library
-            key = bytes(os.environ['GITHUB_SECRET'].encode('ascii'))
-            computed_secret = 'sha1=' + hmac.new(
-                    key, request.body, hashlib.sha1).hexdigest()
-            is_valid_github = hmac.compare_digest(computed_secret, secret)
-            return is_valid_github
-        return False
 
 
 class SocialAuthentication(BaseAuthentication):

--- a/franklin/core/urls.py
+++ b/franklin/core/urls.py
@@ -3,8 +3,8 @@ from django.conf.urls import url
 from .views import health
 from builder.views import UpdateBuildStatus
 from github.views import deploy, deployable_repos, github_webhook, \
-        manage_environments, promote_environment, repository_detail, \
-        repository_list, get_auth_token
+        manage_environments, ProjectDetail, ProjectList, promote_environment, \
+        get_auth_token
 
 urlpatterns = [
     # Github Social Signin
@@ -12,11 +12,12 @@ urlpatterns = [
     url(r'^webhook/$', github_webhook, name='webhook'),
 
     # Registered Repo Operations
-    url(r'^projects/$', repository_list, name='repo_list'),
-    url(r'^repos/(?P<pk>[0-9]+)$', repository_detail, name='repo_details'),
+    url(r'^projects/$', ProjectList.as_view(), name='repo_list'),
+    url(r'^repos/(?P<pk>[0-9]+)$', ProjectDetail.as_view(), name='repo_details'),
     url(r'^repos/(?P<pk>[0-9]+)/deploy$', deploy, name='repo_deploy'),
 
-    url(r'^repos/all/$', deployable_repos, name='deployable_repos'),
+    # Github passthrough endpoints
+    url(r'^repos/$', deployable_repos, name='deployable_repos'),
 
     # Environment management
     url(r'repos/(?P<repo>[0-9]+)/environments$', manage_environments,

--- a/franklin/github/permissions.py
+++ b/franklin/github/permissions.py
@@ -1,0 +1,34 @@
+
+import hmac
+import hashlib
+import os
+
+from rest_framework import permissions
+
+from .api import get_repo_permissions
+
+
+class GithubOnly(permissions.BasePermission):
+    """ Security Check for certain API endpoints only called by Github."""
+
+    def has_permission(self, request, view):
+        secret = request.META.get("HTTP_X_HUB_SIGNATURE")
+        if secret:
+            # must convert to bytes for python 3.5 bug in hmac library
+            key = bytes(os.environ['GITHUB_SECRET'].encode('ascii'))
+            computed_secret = 'sha1=' + hmac.new(
+                    key, request.body, hashlib.sha1).hexdigest()
+            return hmac.compare_digest(computed_secret, secret)
+        return False
+
+
+class UserIsProjectAdmin(permissions.BasePermission):
+    """ Security Check that the POSTing user is an admin for the project"""
+
+    def has_object_permission(self, request, view, obj):
+        if request.method not in ['POST', 'DELETE']:
+            return True
+        perms = get_repo_permissions(obj.owner.name, obj.name, request.user)
+        if perms.get('admin', False):
+            return True
+        return False

--- a/franklin/users/models.py
+++ b/franklin/users/models.py
@@ -6,9 +6,8 @@ from django.db.models.signals import post_save
 from django.utils.translation import ugettext as _
 
 from builder.models import Site
-from core.helpers import make_rest_get_call
+from github.api import get_user_orgs
 
-github_base = 'https://api.github.com/'
 logger = logging.getLogger(__name__)
 
 
@@ -24,45 +23,15 @@ class UserDetails(models.Model):
     sites = models.ManyToManyField(Site, related_name='admins')
 
     def get_user_repos(self):
-        social = self.user.social_auth.get(provider='github')
-        token = social.extra_data['access_token']
-        have_next_page = True
-        url = github_base + 'user/repos?per_page=100'
-        # TODO - Confirm that a header token is the best/most secure way to go
-        headers = {
-                    'content-type': 'application/json',
-                    'Authorization': 'token ' + token
-                  }
-        repos = []
+        # Return all sites owned by the user or one of their org memberships.
 
-        while have_next_page:
-            response = None
-            have_next_page = False  # when in doubt, leave the loop after 1
-            response = make_rest_get_call(url, headers)
-
-            if response is not None:
-                # Add all of the repos to our list
-                for repo in response.json():
-                    repo_data = {}
-                    repo_data['id'] = repo['id']
-                    repo_data['name'] = repo['name']
-                    repo_data['url'] = repo['html_url']
-                    repo_data['owner'] = {}
-                    repo_data['owner']['name'] = repo['owner']['login']
-                    repo_data['owner']['id'] = repo['owner']['id']
-                    repo_data['permissions'] = {}
-                    repo_data['permissions']['admin'] = repo['permissions']['admin']
-                    repos.append(repo_data)
-
-                # If the header has a paging link called 'next', update our url
-                # and continue with the while loop
-                if response.links and response.links.get('next', None):
-                    url = response.links['next']['url']
-                    have_next_page = True
-
-        if not repos:
-            logger.error('Failed to find repos for user', self.user.username)
-        return repos
+        # Init the owners list with the current user as they are an owner
+        owners = [int(self.user.social_auth.get(provider='github').uid)]
+        orgs = get_user_orgs(self.user)
+        for org in orgs:
+            owners.append(org.get('id', ''))
+        return Site.objects.filter(owner__github_id__in=owners)\
+                           .filter(is_active=True).all()
 
     def update_repos_for_user(self, repos):
         # Clear out the users sites in case permissions have changed
@@ -73,14 +42,6 @@ class UserDetails(models.Model):
             if site and repo['permissions']['admin'] == True:
                 self.sites.add(site)
         return self.sites.all()
-
-    def has_repo_access(self, site):
-        if self.sites.count() == 0 or site not in self.sites.all():
-            repos = self.get_user_repos()
-            self.update_repos_for_user(repos)
-        if site in self.sites.all():
-            return True
-        return False
 
     def __str__(self):
         return self.user.username

--- a/franklin/users/tests.py
+++ b/franklin/users/tests.py
@@ -30,20 +30,3 @@ class UserTestCase(TestCase):
         """ Every user that is created should have details
         """
         self.assertIsInstance(self.user.details, UserDetails)
-
-    def test_user_has_repo_access(self):
-        """ Confirm that our user has access to admin the test site
-        """
-        self.assertTrue(self.user.details.has_repo_access(self.site))
-
-    def test_user_has_repo_access_negative(self):
-        """ Confirm that our user has access to admin the test site
-        """
-        self.repos[0]['permissions']['admin'] = False
-        self.assertFalse(self.user.details.has_repo_access(self.site))
-    
-    def test_update_user_repo_access(self):
-        """ When updating the users repos, confirm that they still have access
-        """
-        self.user.details.update_repos_for_user(self.repos)
-        self.assertTrue(self.user.details.has_repo_access(self.site))


### PR DESCRIPTION
Connected to #100 

As referenced in the last PR (107 which is connected to issue 106), POST `/repos` is now located at `/projects`. The payload did not change in that PR, it has changed here though.

POST `/projects` sends a different payload body now. See picture below. `{"github": "owner/repo"}` Also, Both staging and production will be created with the correct settings are you post to this endpoint to register your project. Security update- Posting to this endpoint will return an error if the user token does dot have admin privileges for the repo on github. 

DELETE `/repos/[github_id]`- Same security check as above. If the user isn't an admin, we won't be able to remove the generated deploy key, so that user will not be able to delete. No other change.

GET `/repos/[github_id]` - Removed user object from response. No other change at the moment. The next PR will likely change the payload response and switch it to /projects

GET `/repos/all` has been moved to `/repos`. It is now just a "pass through" to github. As a result, the response payload matches what would come back from Github. (See image below) This will make it easier to parse results should callers of this endpoint wish to call github directly instead. Note also that the payload includes a `full_name` attribute. That value matches exactly with what POST `/projects` now expects.



