### PR TITLE
Listing Github repos no longer broken

### DIFF
--- a/franklin/github/serializers.py
+++ b/franklin/github/serializers.py
@@ -13,8 +13,8 @@ class HeadCommitSerializer(serializers.Serializer):
 
 
 class OwnerSerializer(serializers.Serializer):
-    name = serializers.CharField()
-    email = serializers.CharField()
+    id = serializers.IntegerField(required=False)
+    login = serializers.CharField(required=False)
 
 
 class RepositorySerializer(serializers.Serializer):
@@ -46,6 +46,7 @@ class GithubWebhookSerializer(serializers.Serializer):
     head_commit = HeadCommitSerializer()
     repository = RepositorySerializer()
     ref = serializers.CharField(max_length=100)
+    ref_type = serializers.CharField(max_length=100, required=False)
 
     def get_existing_site(self):
         if self.is_valid():
@@ -57,8 +58,10 @@ class GithubWebhookSerializer(serializers.Serializer):
         return None
 
     def is_tag_event(self):
-        # We stopped supporting tag builds and github changed their api, so
-        # just returning False for now.
+        if self.validated_data:
+            ref_type = self.validated_data.get('ref_type', None)
+            if ref_type and ref_type == 'tag':
+                return True
         return False
 
     def get_event_hash(self):


### PR DESCRIPTION
Connected to #114 

Previous hotfix broke a different call to Github, this fixes it for both issues.