### PR TITLE
/deploy endpoint moved to /builds

### DIFF
--- a/franklin/core/urls.py
+++ b/franklin/core/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 
 from .views import health
 from builder.views import UpdateBuildStatus
-from github.views import deploy, deployable_repos, github_webhook, \
+from github.views import builds, deployable_repos, github_webhook, \
         manage_environments, ProjectDetail, ProjectList, promote_environment, \
         get_auth_token
 
@@ -15,7 +15,9 @@ urlpatterns = [
     url(r'^projects/$', ProjectList.as_view(), name='project_list'),
     url(r'^projects/(?P<pk>[0-9]+)$',
         ProjectDetail.as_view(), name='project_details'),
-    url(r'^repos/(?P<pk>[0-9]+)/deploy$', deploy, name='repo_deploy'),
+
+    # Managing Builds endpoints
+    url(r'^projects/(?P<pk>[0-9]+)/builds$', builds, name='project_builds'),
 
     # Github passthrough endpoints
     url(r'^repos/$', deployable_repos, name='deployable_repos'),


### PR DESCRIPTION
Connected to #116 

POST `/repos/[github_id]/deploy` moved to `/projects/[github_id]/builds`. You no longer pass anything in the payload. The endpoint will automatically deploy the tip of the default branch.

GET `/projects/[github_id]/builds` now exists. Returns the following payload.

![image](https://cloud.githubusercontent.com/assets/444070/13927878/e517f392-ef69-11e5-9f24-28aabe6bc1dd.png)